### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ from scd30 import SCD30
 
 i2cbus = I2C(1)
 scd30 = SCD30(i2c, 0x61)
+scd30.start_continous_measurement()
 
 while True:
     # Wait for sensor data to be ready to read (by default every 2 seconds)


### PR DESCRIPTION
Just had to do some troubleshooting to determine why the `while scd30.get_status_ready() != 1:` was looping infinity in the example code. I determined that my SCD30 sensor came in a non continous measurement state. After adding the line `scd30.start_continous_measurement()` it started working. 

I think this edit would be best or maybe a sentence noting this command as an initialization step in the readme.